### PR TITLE
feat: Joomla data layer — ResultsService

### DIFF
--- a/.squad/agents/frodo/history.md
+++ b/.squad/agents/frodo/history.md
@@ -43,3 +43,12 @@
 - **Prize value formatting:** New Prize column (renders `p.prize` field) implements smart formatting: numeric strings (e.g., "450") render as dollar amounts ("$450"), non-numeric strings render as-is (e.g., "Lee S. Dukes Memorial Award Commemorative Plaque"), missing/null/empty values render as empty `<td></td>`.
 - **Verification passed:** Checked output/article.html — `<th>Name</th>` and `<th>Prize</th>` present in correct order, dollar amounts render correctly (e.g., $450, $250), non-numeric prizes display as plain text, regex pattern `/^\d+(\.\d{1,2})?$/` correctly identifies numeric values for currency formatting.
 
+### Joomla Component Scaffold (2026-03-25)
+- **Status:** Complete. Created `com_showcaseresults` Joomla component scaffold. PR #15 opened to dev.
+- **Files created:** 12 files — manifest XML, controller, view, template (placeholder), menu item XML, service providers (site/admin), language files (en-GB), media folder, build script.
+- **Structure:** `joomla/com_showcaseresults/` with site/, admin/, and media/ folders. Namespace `Mlinnen\Component\ShowcaseResults` registered.
+- **Query params:** View accepts `name`, `carver_id`, `year` parameters. Placeholder template displays them for testing.
+- **Build script:** `joomla/build.ps1` creates `com_showcaseresults.zip` (7.25 KB) — tested successfully.
+- **Placeholders:** Controller and view are minimal skeletons. Business logic (data loading) comes in #10, rendering enhancement in #11, error handling (carver_id without year) in #12.
+- **Joomla compliance:** Manifest compatible with Joomla 4.x and 5.x, PHP 8.1+ requirement, follows modern component structure with service providers and DI container registration.
+

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -35,6 +35,12 @@ Changed the Division Results section in the carver article from a <ul>/<li> list
 ### Issue #7 Decomposition into Sub-Issues (2026-03-25, Gandalf)
 Decomposed issue #7 ("Feature: Joomla component for dynamic per-carver results across all events") into 6 independently implementable sub-issues (#8–#13): CLI JSON export (#8), Joomla component scaffolding (#9), data layer (#10), carver view rendering (#11), error handling & edge cases (#12), testing & verification (#13). Key architectural decision: carver_id is per-event only (privacy constraint); name is the only cross-event lookup key. Dependency graph allows #8 (C# CLI) and #9 (PHP boilerplate) to proceed in parallel. Data layer (#10) separated from view (#11) following MVC; error handling (#12) isolated to keep happy-path code clean. #13 depends on all others. Rationale: parallel development across stacks, independent review of concerns, verification not an afterthought.
 
+### JSON Export Output Path Convention (2026-03-25, Bilbo)
+`--format json` writes `results-{year}.json` to the same directory as HTML output (derived from `Path.GetDirectoryName(--output)`). Default: `output/results-{year}.json`. Year comes from `data.Event.Year` (parsed data), not `--year` CLI flag. Rationale: co-located outputs, filename always matches actual data. Multiple years coexist: `results-2024.json`, `results-2025.json`, etc. Joomla component (#10) expects this path structure.
+
+### Joomla Component Structure (2026-03-25, Frodo)
+Issue #9 — com_showcaseresults scaffold created using modern Joomla 4.x/5.x structure. Namespace: `Mlinnen\Component\ShowcaseResults`. Service providers for site/admin with DI container registration. Query parameters: `name` (cross-event), `carver_id` (per-event, requires year), `year` (event year). Data path: media/com_showcaseresults/data (configurable, receives results-{year}.json from CLI). PHP 8.1+, no legacy compatibility. 12 files delivered: controllers, views, service providers, language files, menu config, build script, installable .zip. MVC separation enables issues #10 (data layer), #11 (view rendering), #12 (error handling) to proceed independently. PR #15: squad/9-joomla-scaffold → dev.
+
 ## Governance
 - All meaningful changes require team consensus
 - Document architectural decisions here

--- a/joomla/com_showcaseresults/site/src/Service/ResultsService.php
+++ b/joomla/com_showcaseresults/site/src/Service/ResultsService.php
@@ -1,0 +1,504 @@
+<?php
+/**
+ * @package     ShowcaseResults
+ * @subpackage  com_showcaseresults
+ * @copyright   Copyright (C) 2026 mlinnen. All rights reserved.
+ * @license     GNU General Public License version 2 or later
+ */
+
+namespace Mlinnen\Component\ShowcaseResults\Site\Service;
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Log\Log;
+
+/**
+ * Service for loading and querying showcase results data
+ *
+ * Provides three lookup modes:
+ * 1. Name cross-event: Searches all results-*.json files for a name
+ * 2. Name single-event: Searches one results file for a name
+ * 3. ID single-event: Searches one results file for a carver_id
+ *
+ * CRITICAL: carver_id is per-event only (privacy by design).
+ * Do NOT attempt to correlate carver_id across events.
+ *
+ * @since 1.0.0
+ */
+class ResultsService
+{
+    /**
+     * Path to the data directory containing results-*.json files
+     *
+     * @var string
+     */
+    private $dataPath;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->dataPath = JPATH_ROOT . '/media/com_showcaseresults/data';
+    }
+
+    /**
+     * Main entry point — dispatches to the correct lookup mode
+     *
+     * @param   string  $name       Carver name (first + last)
+     * @param   int     $carver_id  Per-event carver identifier
+     * @param   int     $year       Event year
+     *
+     * @return  array   Lookup results
+     */
+    public function lookup(string $name = '', int $carver_id = 0, int $year = 0): array
+    {
+        // Validate: carver_id requires year
+        if ($carver_id > 0 && $year === 0)
+        {
+            return [
+                'error' => 'carver_id_requires_year',
+                'results' => []
+            ];
+        }
+
+        // Mode 1: Name cross-event
+        if (!empty($name) && $year === 0)
+        {
+            return $this->lookupByName($name);
+        }
+
+        // Mode 2: Name single-event
+        if (!empty($name) && $year > 0)
+        {
+            return $this->lookupByNameAndYear($name, $year);
+        }
+
+        // Mode 3: ID single-event
+        if ($carver_id > 0 && $year > 0)
+        {
+            return $this->lookupByCarverIdAndYear($carver_id, $year);
+        }
+
+        // No valid lookup parameters
+        return [
+            'error' => 'no_lookup_parameters',
+            'results' => []
+        ];
+    }
+
+    /**
+     * Scan all results files for a name (cross-event)
+     *
+     * @param   string  $name  Carver name (first + last)
+     *
+     * @return  array   Results grouped by event, most recent first
+     */
+    private function lookupByName(string $name): array
+    {
+        $files = $this->getResultsFiles();
+
+        if (empty($files))
+        {
+            return [
+                'error' => 'no_data',
+                'results' => []
+            ];
+        }
+
+        $allResults = [];
+        $carverName = '';
+
+        foreach ($files as $filepath)
+        {
+            $data = $this->loadResultsFile($filepath);
+
+            if ($data === null)
+            {
+                continue;
+            }
+
+            // Search competitors for name match
+            $carverId = $this->findCarverIdByName($data, $name);
+
+            if ($carverId === null)
+            {
+                continue;
+            }
+
+            // Extract results for this carver in this event
+            $eventResults = $this->extractCarverResults($data, $carverId);
+
+            if (!empty($eventResults))
+            {
+                $allResults[] = [
+                    'event_name' => $data['event']['name'] ?? '',
+                    'event_year' => $data['event']['year'] ?? 0,
+                    'special_prizes' => $eventResults['special_prizes'],
+                    'overall_results' => $eventResults['overall_results'],
+                    'division_results' => $eventResults['division_results']
+                ];
+
+                // Capture the name from competitors (first match wins)
+                if (empty($carverName) && isset($data['competitors']))
+                {
+                    foreach ($data['competitors'] as $comp)
+                    {
+                        if ($comp['carver_id'] === $carverId)
+                        {
+                            $carverName = trim($comp['first_name'] . ' ' . $comp['last_name']);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Sort by year descending
+        usort($allResults, function($a, $b) {
+            return $b['event_year'] - $a['event_year'];
+        });
+
+        return [
+            'carver_name' => $carverName,
+            'found' => !empty($allResults),
+            'results' => $allResults
+        ];
+    }
+
+    /**
+     * Scan one results file for a name (single-event)
+     *
+     * @param   string  $name  Carver name (first + last)
+     * @param   int     $year  Event year
+     *
+     * @return  array   Results for the specified event
+     */
+    private function lookupByNameAndYear(string $name, int $year): array
+    {
+        $filepath = $this->dataPath . '/results-' . $year . '.json';
+
+        if (!file_exists($filepath))
+        {
+            return [
+                'found' => false,
+                'results' => []
+            ];
+        }
+
+        $data = $this->loadResultsFile($filepath);
+
+        if ($data === null)
+        {
+            return [
+                'error' => 'data_load_error',
+                'found' => false,
+                'results' => []
+            ];
+        }
+
+        // Search competitors for name match
+        $carverId = $this->findCarverIdByName($data, $name);
+
+        if ($carverId === null)
+        {
+            return [
+                'found' => false,
+                'results' => []
+            ];
+        }
+
+        // Extract results for this carver
+        $eventResults = $this->extractCarverResults($data, $carverId);
+
+        $carverName = '';
+        if (isset($data['competitors']))
+        {
+            foreach ($data['competitors'] as $comp)
+            {
+                if ($comp['carver_id'] === $carverId)
+                {
+                    $carverName = trim($comp['first_name'] . ' ' . $comp['last_name']);
+                    break;
+                }
+            }
+        }
+
+        return [
+            'carver_name' => $carverName,
+            'found' => !empty($eventResults['special_prizes']) || 
+                       !empty($eventResults['overall_results']) || 
+                       !empty($eventResults['division_results']),
+            'results' => [
+                [
+                    'event_name' => $data['event']['name'] ?? '',
+                    'event_year' => $data['event']['year'] ?? 0,
+                    'special_prizes' => $eventResults['special_prizes'],
+                    'overall_results' => $eventResults['overall_results'],
+                    'division_results' => $eventResults['division_results']
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Scan one results file for a carver_id (single-event only)
+     *
+     * @param   int  $carver_id  Per-event carver identifier
+     * @param   int  $year       Event year
+     *
+     * @return  array   Results for the specified carver
+     */
+    private function lookupByCarverIdAndYear(int $carver_id, int $year): array
+    {
+        $filepath = $this->dataPath . '/results-' . $year . '.json';
+
+        if (!file_exists($filepath))
+        {
+            return [
+                'found' => false,
+                'results' => []
+            ];
+        }
+
+        $data = $this->loadResultsFile($filepath);
+
+        if ($data === null)
+        {
+            return [
+                'error' => 'data_load_error',
+                'found' => false,
+                'results' => []
+            ];
+        }
+
+        // Extract results for this carver
+        $eventResults = $this->extractCarverResults($data, $carver_id);
+
+        $carverName = '';
+        if (isset($data['competitors']))
+        {
+            foreach ($data['competitors'] as $comp)
+            {
+                if ($comp['carver_id'] === $carver_id)
+                {
+                    $carverName = trim($comp['first_name'] . ' ' . $comp['last_name']);
+                    break;
+                }
+            }
+        }
+
+        return [
+            'carver_name' => $carverName,
+            'found' => !empty($eventResults['special_prizes']) || 
+                       !empty($eventResults['overall_results']) || 
+                       !empty($eventResults['division_results']),
+            'results' => [
+                [
+                    'event_name' => $data['event']['name'] ?? '',
+                    'event_year' => $data['event']['year'] ?? 0,
+                    'special_prizes' => $eventResults['special_prizes'],
+                    'overall_results' => $eventResults['overall_results'],
+                    'division_results' => $eventResults['division_results']
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Helper: load and parse a single JSON file
+     *
+     * @param   string  $filepath  Full path to JSON file
+     *
+     * @return  array|null  Parsed data or null on error
+     */
+    private function loadResultsFile(string $filepath): ?array
+    {
+        if (!file_exists($filepath))
+        {
+            return null;
+        }
+
+        $content = file_get_contents($filepath);
+
+        if ($content === false)
+        {
+            Log::add('Failed to read file: ' . $filepath, Log::WARNING, 'com_showcaseresults');
+            return null;
+        }
+
+        $data = json_decode($content, true);
+
+        if ($data === null)
+        {
+            Log::add('Failed to parse JSON in file: ' . $filepath, Log::WARNING, 'com_showcaseresults');
+            return null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Helper: get all results-*.json file paths
+     *
+     * @return  array  Array of file paths, sorted by year descending
+     */
+    private function getResultsFiles(): array
+    {
+        if (!is_dir($this->dataPath))
+        {
+            return [];
+        }
+
+        $files = glob($this->dataPath . '/results-*.json');
+
+        if ($files === false)
+        {
+            return [];
+        }
+
+        // Sort by filename (year) descending
+        rsort($files);
+
+        return $files;
+    }
+
+    /**
+     * Helper: filter event data for a specific carver_id
+     *
+     * @param   array  $data       Parsed results data
+     * @param   int    $carver_id  Carver identifier
+     *
+     * @return  array  Filtered results arrays
+     */
+    private function extractCarverResults(array $data, int $carver_id): array
+    {
+        $results = [
+            'special_prizes' => [],
+            'overall_results' => [],
+            'division_results' => []
+        ];
+
+        // Filter special prizes
+        if (isset($data['special_prizes']))
+        {
+            foreach ($data['special_prizes'] as $prize)
+            {
+                if (isset($prize['carver_id']) && $prize['carver_id'] === $carver_id)
+                {
+                    $results['special_prizes'][] = $prize;
+                }
+            }
+        }
+
+        // Filter overall results
+        if (isset($data['overall_results']))
+        {
+            foreach ($data['overall_results'] as $category)
+            {
+                $matchingPlaces = [];
+
+                if (isset($category['places']))
+                {
+                    foreach ($category['places'] as $place)
+                    {
+                        if (isset($place['carver_id']) && $place['carver_id'] === $carver_id)
+                        {
+                            $matchingPlaces[] = $place;
+                        }
+                    }
+                }
+
+                if (!empty($matchingPlaces))
+                {
+                    $results['overall_results'][] = [
+                        'category' => $category['category'] ?? '',
+                        'places' => $matchingPlaces
+                    ];
+                }
+            }
+        }
+
+        // Filter division results
+        if (isset($data['division_results']))
+        {
+            foreach ($data['division_results'] as $division)
+            {
+                $matchingCategories = [];
+
+                if (isset($division['categories']))
+                {
+                    foreach ($division['categories'] as $category)
+                    {
+                        $matchingPlaces = [];
+
+                        if (isset($category['places']))
+                        {
+                            foreach ($category['places'] as $place)
+                            {
+                                if (isset($place['carver_id']) && $place['carver_id'] === $carver_id)
+                                {
+                                    $matchingPlaces[] = $place;
+                                }
+                            }
+                        }
+
+                        if (!empty($matchingPlaces))
+                        {
+                            $matchingCategories[] = [
+                                'name' => $category['name'] ?? '',
+                                'style' => $category['style'] ?? null,
+                                'places' => $matchingPlaces
+                            ];
+                        }
+                    }
+                }
+
+                if (!empty($matchingCategories))
+                {
+                    $results['division_results'][] = [
+                        'division' => $division['division'] ?? '',
+                        'categories' => $matchingCategories
+                    ];
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Helper: find carver_id by name match in competitors array
+     *
+     * @param   array   $data  Parsed results data
+     * @param   string  $name  Name to search for (case-insensitive)
+     *
+     * @return  int|null  Carver ID or null if not found
+     */
+    private function findCarverIdByName(array $data, string $name): ?int
+    {
+        if (!isset($data['competitors']) || !is_array($data['competitors']))
+        {
+            return null;
+        }
+
+        $searchName = strtolower(trim($name));
+
+        foreach ($data['competitors'] as $comp)
+        {
+            if (!isset($comp['first_name']) || !isset($comp['last_name']) || !isset($comp['carver_id']))
+            {
+                continue;
+            }
+
+            $fullName = strtolower(trim($comp['first_name'] . ' ' . $comp['last_name']));
+
+            if ($fullName === $searchName)
+            {
+                return $comp['carver_id'];
+            }
+        }
+
+        return null;
+    }
+}

--- a/joomla/com_showcaseresults/site/src/View/Carver/HtmlView.php
+++ b/joomla/com_showcaseresults/site/src/View/Carver/HtmlView.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Factory;
+use Mlinnen\Component\ShowcaseResults\Site\Service\ResultsService;
 
 /**
  * HTML view for Carver results
@@ -22,7 +23,6 @@ use Joomla\CMS\Factory;
  * - year: Event year (required when using carver_id)
  *
  * Note: carver_id without year is invalid (privacy by design).
- * Data loading logic will be implemented in issue #10.
  * Template rendering will be enhanced in issue #11.
  * Error handling for invalid params will be added in issue #12.
  *
@@ -30,6 +30,13 @@ use Joomla\CMS\Factory;
  */
 class HtmlView extends BaseHtmlView
 {
+    /**
+     * Carver data from ResultsService
+     *
+     * @var array
+     */
+    public $carverData;
+
     /**
      * Display the view
      *
@@ -43,12 +50,23 @@ class HtmlView extends BaseHtmlView
         $input = $app->input;
 
         // Get query parameters
-        $this->name = $input->getString('name', '');
-        $this->carver_id = $input->getInt('carver_id', 0);
-        $this->year = $input->getInt('year', 0);
+        $name = $input->getString('name', '');
+        $carver_id = $input->getInt('carver_id', 0);
+        $year = $input->getInt('year', 0);
 
-        // Business logic placeholder — data loading comes in issue #10
-        // Error handling for carver_id without year comes in issue #12
+        // Load data via ResultsService
+        $service = new ResultsService();
+        $this->carverData = $service->lookup($name, $carver_id, $year);
+
+        // Set page title
+        if (!empty($this->carverData['carver_name']))
+        {
+            $this->document->setTitle($this->carverData['carver_name'] . ' - Showcase Results');
+        }
+        else
+        {
+            $this->document->setTitle('Carver Results');
+        }
 
         parent::display($tpl);
     }

--- a/joomla/com_showcaseresults/site/tmpl/carver/default.php
+++ b/joomla/com_showcaseresults/site/tmpl/carver/default.php
@@ -8,30 +8,26 @@
 
 defined('_JEXEC') or die;
 
-// Placeholder template for carver results view
-// This will be enhanced with actual rendering logic in issue #11
-
 ?>
 <div class="showcaseresults-carver">
-    <h2>Showcase Results - Carver View (placeholder)</h2>
+    <h2>Showcase Results - Carver View</h2>
     
-    <?php if (!empty($this->name)): ?>
-        <p><strong>Name:</strong> <?php echo htmlspecialchars($this->name); ?></p>
-    <?php endif; ?>
-    
-    <?php if (!empty($this->carver_id)): ?>
-        <p><strong>Carver ID:</strong> <?php echo (int) $this->carver_id; ?></p>
-    <?php endif; ?>
-    
-    <?php if (!empty($this->year)): ?>
-        <p><strong>Year:</strong> <?php echo (int) $this->year; ?></p>
-    <?php endif; ?>
-    
-    <?php if (!empty($this->carver_id) && empty($this->year)): ?>
+    <?php if (isset($this->carverData['error'])): ?>
         <div class="alert alert-warning">
-            <p><strong>Note:</strong> carver_id requires a year parameter (error handling comes in issue #12)</p>
+            <p><strong>Error:</strong> <?php echo htmlspecialchars($this->carverData['error']); ?></p>
         </div>
     <?php endif; ?>
     
-    <p class="text-muted">Full rendering logic will be implemented in issue #11</p>
+    <?php if (!empty($this->carverData['carver_name'])): ?>
+        <h3><?php echo htmlspecialchars($this->carverData['carver_name']); ?></h3>
+    <?php endif; ?>
+    
+    <?php if (isset($this->carverData['found']) && $this->carverData['found'] === false): ?>
+        <p class="text-muted">No results found for the specified carver.</p>
+    <?php elseif (!empty($this->carverData['results'])): ?>
+        <div class="results-data">
+            <h4>Data Loaded (Raw Output — Rendering Enhancement in Issue #11)</h4>
+            <pre><?php var_dump($this->carverData); ?></pre>
+        </div>
+    <?php endif; ?>
 </div>


### PR DESCRIPTION
Closes #10

Implements PHP data layer for loading, parsing, and aggregating results-*.json files. Provides three lookup modes: by name (cross-event), by name+year, and by carver_id+year.

## What's Implemented

### ResultsService.php (504 lines)
- **lookup()**: Main entry point, dispatches to correct mode
- **lookupByName()**: Cross-event name search (all JSON files)
- **lookupByNameAndYear()**: Single-event name search
- **lookupByCarverIdAndYear()**: Single-event ID search
- **extractCarverResults()**: Filters special prizes, overall results, division results
- **findCarverIdByName()**: Case-insensitive name matching in competitors array

### Key Design Constraints
- **carver_id is per-event only** (privacy feature) — cannot be used to correlate across events
- **name is the only cross-event identifier**
- Results sorted by year descending

### Edge Cases Handled
- carver_id without year → \rror: 'carver_id_requires_year'\
- Name not found → \ound: false\
- No JSON files → \rror: 'no_data'\
- Malformed JSON → skip with warning, continue with other files

### Updated Files
- **HtmlView.php**: Instantiates ResultsService, calls lookup(), sets page title
- **default.php**: Displays carverData (var_dump for now — real rendering in #11)

## Testing
Template currently outputs raw data with var_dump. Real HTML rendering comes in issue #11.

## Dependencies
Depends on #9 (Joomla component scaffold).