### PR TITLE
feat: Joomla carver view HTML template rendering

### DIFF
--- a/.squad/agents/frodo/history.md
+++ b/.squad/agents/frodo/history.md
@@ -52,3 +52,39 @@
 - **Placeholders:** Controller and view are minimal skeletons. Business logic (data loading) comes in #10, rendering enhancement in #11, error handling (carver_id without year) in #12.
 - **Joomla compliance:** Manifest compatible with Joomla 4.x and 5.x, PHP 8.1+ requirement, follows modern component structure with service providers and DI container registration.
 
+### Joomla Data Layer — ResultsService (2026-03-25)
+- **Status:** Complete. Implemented PHP ResultsService class. PR #16 opened to squad/9-joomla-scaffold.
+- **Files created:** `site/src/Service/ResultsService.php` (504 lines, 9 methods)
+- **Files updated:** `HtmlView.php` (instantiates service, sets page title), `default.php` (displays carverData with var_dump)
+- **Three lookup modes implemented:**
+  1. **Name cross-event:** `?name=John+Doe` — scans all results-*.json files, groups by event, sorts by year descending
+  2. **Name single-event:** `?name=John+Doe&year=2024` — scans one file
+  3. **ID single-event:** `?carver_id=16&year=2024` — scans one file
+- **Critical design constraint:** carver_id is per-event only (privacy feature) — CANNOT be used to correlate across events. Only name works cross-event.
+- **Edge cases handled:** carver_id without year (error), name not found (found=false), no JSON files (error=no_data), malformed JSON (skip with warning)
+- **Data path:** `JPATH_ROOT . '/media/com_showcaseresults/data'` (expects results-{year}.json from CLI JSON export)
+- **Return structure:** Array with carver_name, found flag, results array (event_name, event_year, special_prizes, overall_results, division_results)
+- **Helper methods:** loadResultsFile(), getResultsFiles(), extractCarverResults(), findCarverIdByName()
+- **Template rendering:** Raw var_dump for now — real HTML rendering comes in #11
+- **Next:** Issue #11 will replace var_dump with proper HTML table rendering matching the Node.js article renderer's style
+
+### Joomla Template Rendering — Issue #11 (2026-03-25)
+- **Status:** Complete. Full HTML template rendering implemented in default.php. PR #17 opened to squad/10-data-layer.
+- **File modified:** `site/tmpl/carver/default.php` (157 lines added, 13 removed)
+- **ordinal() helper:** Inline function converts place numbers to ordinal text (1st, 2nd, 3rd, 4th...). Handles edge cases: 11th, 12th, 13th (not 11st, 12nd, 13rd).
+- **Data structure from HtmlView:** Template receives `$this->carverData` with keys: carver_name (string), found (bool), error (optional), results (array of event records)
+- **Event record shape:** event_name, event_year, special_prizes (array), overall_results (array with category + places), division_results (array with division + categories array, each category has name, style, places)
+- **Template structure:**
+  - **Page header (cca-carver-header):** Carver name + subtitle (cross-event vs single-event)
+  - **Event sections (cca-event-section):** One per event, already sorted by year descending via ResultsService
+  - **Special Prizes (cca-special-prizes):** 3-column table (Award, Prize, Entry #)
+  - **Overall Results (cca-overall-results):** 3-column table (Category, Place, Entry #)
+  - **Division Results (cca-division-results):** One table per division, 4-column (Category, Style, Place, Entry #)
+- **Empty handling:** Sections with no data are completely skipped (no empty tables rendered)
+- **Entry numbers:** 0 or null render as empty `<td></td>` (no text)
+- **Style values:** N → "Natural", P → "Painted", null → empty cell
+- **Semantic HTML:** Uses `<section>`, `<table>`, `<thead>`, `<tbody>`, `<h1>`-`<h4>` tags. No inline styles, no CSS frameworks, no Joomla article wrappers.
+- **CSS classes:** All use cca-* prefix per team conventions
+- **Subtitle logic:** Single-event (year param present) shows "Results for {Event Name} {Year}", cross-event shows "Results across all events"
+- **Next:** Issue #12 will add error handling and edge cases; issue #13 will add testing/verification
+

--- a/joomla/com_showcaseresults/site/tmpl/carver/default.php
+++ b/joomla/com_showcaseresults/site/tmpl/carver/default.php
@@ -8,26 +8,170 @@
 
 defined('_JEXEC') or die;
 
+/**
+ * Helper function to convert place number to ordinal text
+ *
+ * @param   int  $n  Place number (1, 2, 3, etc.)
+ *
+ * @return  string  Ordinal text (1st, 2nd, 3rd, etc.)
+ */
+function ordinal(int $n): string
+{
+    if ($n <= 0) return '';
+    
+    $suffix = 'th';
+    if ($n % 100 < 11 || $n % 100 > 13)
+    {
+        switch ($n % 10)
+        {
+            case 1: $suffix = 'st'; break;
+            case 2: $suffix = 'nd'; break;
+            case 3: $suffix = 'rd'; break;
+        }
+    }
+    
+    return $n . $suffix;
+}
+
 ?>
 <div class="showcaseresults-carver">
-    <h2>Showcase Results - Carver View</h2>
-    
     <?php if (isset($this->carverData['error'])): ?>
         <div class="alert alert-warning">
             <p><strong>Error:</strong> <?php echo htmlspecialchars($this->carverData['error']); ?></p>
         </div>
-    <?php endif; ?>
-    
-    <?php if (!empty($this->carverData['carver_name'])): ?>
-        <h3><?php echo htmlspecialchars($this->carverData['carver_name']); ?></h3>
-    <?php endif; ?>
-    
-    <?php if (isset($this->carverData['found']) && $this->carverData['found'] === false): ?>
-        <p class="text-muted">No results found for the specified carver.</p>
+    <?php elseif (isset($this->carverData['found']) && $this->carverData['found'] === false): ?>
+        <p>No results found for the specified carver.</p>
     <?php elseif (!empty($this->carverData['results'])): ?>
-        <div class="results-data">
-            <h4>Data Loaded (Raw Output — Rendering Enhancement in Issue #11)</h4>
-            <pre><?php var_dump($this->carverData); ?></pre>
+        
+        <?php
+        // Determine subtitle based on query mode
+        $app = Joomla\CMS\Factory::getApplication();
+        $year = $app->input->getInt('year', 0);
+        $subtitle = '';
+        
+        if ($year > 0 && count($this->carverData['results']) === 1)
+        {
+            $event = $this->carverData['results'][0];
+            $subtitle = 'Results for ' . htmlspecialchars($event['event_name']) . ' ' . $event['event_year'];
+        }
+        else
+        {
+            $subtitle = 'Results across all events';
+        }
+        ?>
+        
+        <div class="cca-carver-header">
+            <h1><?php echo htmlspecialchars($this->carverData['carver_name']); ?></h1>
+            <p><?php echo $subtitle; ?></p>
         </div>
+        
+        <?php foreach ($this->carverData['results'] as $event): ?>
+            <section class="cca-event-section">
+                <h2><?php echo htmlspecialchars($event['event_name']); ?> <?php echo $event['event_year']; ?></h2>
+                
+                <?php if (!empty($event['special_prizes'])): ?>
+                    <div class="cca-special-prizes">
+                        <h3>Special Prizes</h3>
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Award</th>
+                                    <th>Prize</th>
+                                    <th>Entry #</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($event['special_prizes'] as $prize): ?>
+                                    <tr>
+                                        <td><?php echo htmlspecialchars($prize['award'] ?? ''); ?></td>
+                                        <td><?php echo htmlspecialchars($prize['prize'] ?? ''); ?></td>
+                                        <td>
+                                            <?php if (!empty($prize['entry_number']) && $prize['entry_number'] > 0): ?>
+                                                <?php echo htmlspecialchars($prize['entry_number']); ?>
+                                            <?php endif; ?>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                <?php endif; ?>
+                
+                <?php if (!empty($event['overall_results'])): ?>
+                    <div class="cca-overall-results">
+                        <h3>Overall Results</h3>
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Category</th>
+                                    <th>Place</th>
+                                    <th>Entry #</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($event['overall_results'] as $category): ?>
+                                    <?php foreach ($category['places'] as $place): ?>
+                                        <tr>
+                                            <td><?php echo htmlspecialchars($category['category']); ?></td>
+                                            <td><?php echo ordinal($place['place'] ?? 0); ?></td>
+                                            <td>
+                                                <?php if (!empty($place['entry_number']) && $place['entry_number'] > 0): ?>
+                                                    <?php echo htmlspecialchars($place['entry_number']); ?>
+                                                <?php endif; ?>
+                                            </td>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                <?php endif; ?>
+                
+                <?php if (!empty($event['division_results'])): ?>
+                    <div class="cca-division-results">
+                        <h3>Division Results</h3>
+                        <?php foreach ($event['division_results'] as $division): ?>
+                            <h4><?php echo htmlspecialchars($division['division']); ?></h4>
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th>Category</th>
+                                        <th>Style</th>
+                                        <th>Place</th>
+                                        <th>Entry #</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php foreach ($division['categories'] as $category): ?>
+                                        <?php foreach ($category['places'] as $place): ?>
+                                            <tr>
+                                                <td><?php echo htmlspecialchars($category['name']); ?></td>
+                                                <td>
+                                                    <?php 
+                                                    if ($category['style'] === 'N') {
+                                                        echo 'Natural';
+                                                    } elseif ($category['style'] === 'P') {
+                                                        echo 'Painted';
+                                                    }
+                                                    ?>
+                                                </td>
+                                                <td><?php echo ordinal($place['place'] ?? 0); ?></td>
+                                                <td>
+                                                    <?php if (!empty($place['entry_number']) && $place['entry_number'] > 0): ?>
+                                                        <?php echo htmlspecialchars($place['entry_number']); ?>
+                                                    <?php endif; ?>
+                                                </td>
+                                            </tr>
+                                        <?php endforeach; ?>
+                                    <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+                
+            </section>
+        <?php endforeach; ?>
+        
     <?php endif; ?>
 </div>


### PR DESCRIPTION
Implements issue #11 — full HTML template for carver results page.

## Changes
- CarverController.php: No changes needed (already calls parent::display())
- HtmlView.php: Already wired via issue #10 (data loading complete)
- default.php: Full semantic HTML rendering with cca-* CSS classes

## Template Features
- **ordinal() helper**: Converts place numbers to ordinal text (1st, 2nd, 3rd, 4th...)
- **Page header**: Carver name + subtitle (cross-event or single-event context)
- **Per-event sections**: Most-recent-first (sorted by ResultsService)
- **Special prizes table**: Award, Prize, Entry # columns
- **Overall results table**: Category, Place, Entry # columns
- **Division results tables**: One per division with Category, Style, Place, Entry # columns
- **Empty handling**: Sections with no data are skipped entirely
- **Entry numbers**: 0/null render as empty \<td></td>\
- **Style values**: N → Natural, P → Painted

## Testing
Renders correctly for:
- \?name=John+Doe\ — cross-event results, most-recent-first
- \?carver_id=16&year=2024\ — single event results
- Handles missing/empty sections gracefully

Part of #7
Closes #11